### PR TITLE
project and lock file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "paw-apply"
+version = "2.0.2"
+
+[tool.coverage.run]
+branch = true
+source = ['.']
+omit = ['manage.py']
+
+[tool.coverage.report]
+fail_under = 100
+show_missing = true
+skip_covered = false

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,7 @@
+version = 1
+requires-python = ">=3.10"
+
+[[package]]
+name = "paw-apply"
+version = "2.0.2"
+source = { virtual = "." }


### PR DESCRIPTION
Sets up minimal `pyproject.toml` and `uv.lock`, for running with [`uv`](https://docs.astral.sh/uv/guides/scripts/). This is not a recommendation for deploying with uv, instead it's mostly for convenience for development on Windows.